### PR TITLE
added 'xgboost' to ml-methods

### DIFF
--- a/Survival.md
+++ b/Survival.md
@@ -684,7 +684,9 @@ Machine learning
     in the `r pkg("gbm")` package. The
     `r pkg("mboost")` package includes a generic gradient
     boosting algorithm for the construction of prognostic and diagnostic
-    models for right-censored data.
+    models for right-censored data. `r pkg("xgboost")` includes methods
+    for Cox regression (right censored survival data) and AFT models
+    (right-, left-, interval-, and uncensored).
 -   ***Other:*** The `r pkg("superpc")` package implements
     the supervised principal components for survival data. The
     `r pkg("compound.Cox")` package fits Cox proportional


### PR DESCRIPTION
[`xgboost`](https://xgboost.readthedocs.io/en/stable/) is a very popular gradient boosting algorithm. It offers an API for survival data, namely to fit Cox- and AFT-models. This PR adds `xgboost` to the section "Machine learning" as it is yet missing there.

More information:

- > `survival:cox`: Cox regression for right censored survival time data (negative values are considered right censored). Note that predictions are returned on the hazard ratio scale (i.e., as HR = exp(marginal_prediction) in the proportional hazard function h(t) = h0(t) * HR).
`survival:aft`: Accelerated failure time model for censored survival time data. See [Survival Analysis with Accelerated Failure Time](https://xgboost.readthedocs.io/en/stable/tutorials/aft_survival_analysis.html) for details.

    Source: [https://xgboost.readthedocs.io/en/stable/parameter.html#learning-task-parameters](https://xgboost.readthedocs.io/en/stable/parameter.html#learning-task-parameters)

- > `cox-nloglik`: negative partial log-likelihood for Cox proportional hazards regression
`aft-nloglik`: Negative log likelihood of Accelerated Failure Time model. See [Survival Analysis with Accelerated Failure Time](https://xgboost.readthedocs.io/en/stable/tutorials/aft_survival_analysis.html) for details.

    Source: [https://xgboost.readthedocs.io/en/stable/parameter.html#learning-task-parameters](https://xgboost.readthedocs.io/en/stable/parameter.html#learning-task-parameters)

- [Survival Analysis with Accelerated Failure Time](https://xgboost.readthedocs.io/en/stable/tutorials/aft_survival_analysis.html#survival-analysis-with-accelerated-failure-time)